### PR TITLE
Fix PIM buffer mem_acc scaling

### DIFF
--- a/src/ramulator_wrapper.py
+++ b/src/ramulator_wrapper.py
@@ -258,7 +258,7 @@ class Ramulator:
                 # pCH * Rank * bank group
                 mem_acc *= 2 * 2 * 4
             else:
-                mem_acc *= 2
+                mem_acc *= 1
 
             ## si, tsv, giomux to bgmux, bgmux to column decoder, bank RD
             traffic = [si_io, tsv_io, giomux_io, bgmux_io, mem_acc]


### PR DESCRIPTION
## Summary
- correct memory access scaling for `PIMType.BUFFER` in `Ramulator`

## Testing
- `pylint src/*.py`
- `python -m compileall -q src`


------
https://chatgpt.com/codex/tasks/task_e_6847dc5a1a5c8324829ffadb3c23f307